### PR TITLE
Fix scope of Neti namespace object

### DIFF
--- a/Resources/frontend/js/hidePaymentSelect.js
+++ b/Resources/frontend/js/hidePaymentSelect.js
@@ -1,6 +1,6 @@
 ;
 if ('undefined' === typeof Neti) {
-    let Neti;
+    var Neti;
 }
 
 Neti = Neti || {};


### PR DESCRIPTION
I tried using `let` here for better scoping and improved fanciness but forgot that `Neti` actually NEEDS to be global.