### PR TITLE
#29147 - Fix zero amount order detection

### DIFF
--- a/Subscriber/FrontendCheckout.php
+++ b/Subscriber/FrontendCheckout.php
@@ -102,9 +102,11 @@ class FrontendCheckout implements SubscriberInterface
      */
     private function isZeroAmountOrder()
     {
-        $orderVariables = $this->session->get('sOrderVariables', new \ArrayObject());
+        if (null !== $orderVariables = $this->session->get('sOrderVariables')) {
+            return !(.0 < \round($orderVariables['sAmount'], 2) || .0 < \round($orderVariables['sAmountWithTax'], 2));
+        }
 
-        return !(.0 < \round($orderVariables['sAmount'], 2) || .0 < \round($orderVariables['sAmountWithTax'], 2));
+        return !(.0 < \round($this->session->get('sBasketAmount'), 2));
     }
 
     /**

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,10 +5,19 @@
     <label lang="de">OrderAmountHandler</label>
     <label lang="en">OrderAmountHandler</label>
 
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <link>http://www.netinventors.de</link>
     <author>Net Inventors GmbH</author>
     <compatibility minVersion="5.3.0"/>
+
+    <changelog version="1.0.4">
+        <changes lang="de"><![CDATA[
+[#29147] Fehlerkorrektur bei Schnellbestellungen und nach Registrierung
+]]></changes>
+        <changes lang="en"><![CDATA[
+[#29147] Bugfix for guest orders and after registration
+]]></changes>
+    </changelog>
 
     <changelog version="1.0.3">
         <changes lang="de"><![CDATA[Initialveröffentlichung im Community Store]]></changes>


### PR DESCRIPTION
This resolves an issue, that occured right after registration and on guest orders.
Baskets with an amount greater than zero have been considered as a zero amount order.

To test it, just create baskets with an amount > 0 and with an amount = 0 for guest accounts and logged in users.
For zero amount orders, the "Kostenlos" payment method should be taken. In all other cases, th default payment method should be selected.